### PR TITLE
fix: Update funding and account docs for USDC-only flow

### DIFF
--- a/how-to/create-account.mdx
+++ b/how-to/create-account.mdx
@@ -7,17 +7,21 @@ description: Get set up on Shareland in minutes.
 
 Visit [share.land](https://share.land) and click **Log In** in the top right corner.
 
-## Step 2: Connect your wallet
+## Step 2: Sign in
 
-A Privy popup will appear. Connect any Web3 wallet: MetaMask, Coinbase Wallet, Rainbow, or any WalletConnect-compatible wallet.
+A Privy popup will appear. You can sign in with:
+
+- **Email** — enter your email and verify with a code
+- **Google** — sign in with your Google account
+- **External wallet** — connect MetaMask, Coinbase Wallet, Rainbow, or any WalletConnect-compatible wallet
 
 <Frame caption="Shareland: Log in or sign up">
   <img src="/images/screenshots/create-account.png" alt="Privy login modal" />
 </Frame>
 
-<Note>
-  Additional login methods (email, social, SMS) are on the roadmap. Currently, a Web3 wallet with USDC on Base is required to start trading.
-</Note>
+<Tip>
+  If you sign in with email or Google, Shareland creates a secure wallet for you automatically — no crypto experience needed.
+</Tip>
 
 ## Step 3: Start exploring
 

--- a/how-to/fund-your-account.mdx
+++ b/how-to/fund-your-account.mdx
@@ -1,20 +1,17 @@
 ---
 title: Fund Your Account
-description: How to get USDC and ETH on Base so you can trade on Shareland.
+description: How to get USDC on Base so you can trade on Shareland.
 ---
 
-Shareland runs on the **Base** network. To trade, you need:
-
-- **USDC** — the currency used to buy and sell SQFT tokens
-- **A small amount of ETH** — to cover gas fees (typically less than $0.01 per transaction)
+Shareland runs on the **Base** network. To trade, you need **USDC** — the currency used to buy and sell SQFT tokens.
 
 <Note>
-  Both USDC and ETH must be on the **Base** network specifically. Funds on Ethereum mainnet, Arbitrum, Polygon, or other networks will not appear in Shareland.
+  USDC must be on the **Base** network specifically. Funds on Ethereum mainnet, Arbitrum, Polygon, or other networks will not appear in Shareland.
 </Note>
 
-## Step 1: Buy USDC and ETH
+## Step 1: Buy USDC
 
-Purchase USDC and ETH from a crypto exchange. Popular options include:
+Purchase USDC from a crypto exchange. Popular options include:
 
 - [Coinbase](https://www.coinbase.com) — supports direct withdrawals to Base
 - [Kraken](https://www.kraken.com)
@@ -26,7 +23,7 @@ Purchase USDC and ETH from a crypto exchange. Popular options include:
 
 ## Step 2: Send to your wallet on Base
 
-Withdraw USDC and ETH from the exchange to your wallet address. When withdrawing:
+Withdraw USDC from the exchange to your wallet address. When withdrawing:
 
 1. Copy your wallet's public address (the same address you use to log into Shareland)
 2. In the exchange withdrawal screen, paste your wallet address
@@ -41,18 +38,18 @@ Withdraw USDC and ETH from the exchange to your wallet address. When withdrawing
 Once the transfer completes (usually within a few minutes):
 
 1. Go to [share.land](https://share.land) and connect your wallet
-2. Your USDC and ETH balances should appear automatically
+2. Your USDC balance should appear automatically
 3. You're ready to trade
 
 <Check>
-  If your USDC and ETH balances appear on [share.land](https://share.land), you're all set to start trading.
+  If your USDC balance appears on [share.land](https://share.land), you're all set to start trading.
 </Check>
 
 ## Common Mistakes
 
 ### Sent funds on the wrong network
 
-If you accidentally sent USDC or ETH on Ethereum mainnet, Arbitrum, or another network instead of Base:
+If you accidentally sent USDC on Ethereum mainnet, Arbitrum, or another network instead of Base:
 
 1. **Don't panic** — your funds are not lost, they're just on a different network
 2. Send them back to your exchange account (on the network you used)
@@ -73,8 +70,8 @@ If your transfer completed but your balance isn't showing in Shareland:
 ## FAQ
 
 <AccordionGroup>
-  <Accordion title="How much ETH do I need for gas?">
-    Very little. Base gas fees are typically under $0.01 per transaction. Having $1–2 worth of ETH is more than enough for hundreds of trades.
+  <Accordion title="Do I need ETH for gas fees?">
+    Most wallets (MetaMask, Coinbase Wallet, etc.) handle gas fees automatically using your USDC — no ETH needed. If your wallet does not support this, a very small amount of ETH on Base (less than $0.01 per trade) may be required.
   </Accordion>
   <Accordion title="Is there a minimum amount of USDC I need?">
     There is no minimum trade size on Shareland. A minimum fee of $0.10 applies per transaction, so very small trades may not be cost-efficient.

--- a/reference/faq.mdx
+++ b/reference/faq.mdx
@@ -60,8 +60,11 @@ description: Answers to the most common questions about Shareland.
   <Accordion title="Are there tax implications?">
     Tax treatment of synthetic derivative instruments varies by jurisdiction. Shareland does not provide tax advice. We recommend consulting a tax professional familiar with digital assets in your country.
   </Accordion>
+  <Accordion title="How do I sign up?">
+    Visit [share.land](https://share.land) and click **Log In**. You can sign in with email, Google, or an external wallet (MetaMask, Coinbase Wallet, etc.). If you use email or Google, a secure wallet is created for you automatically.
+  </Accordion>
   <Accordion title="How do I add funds to trade?">
-    You'll need USDC on the Base network to start trading. There is no in-app on-ramp currently. You'll need to acquire USDC on Base through your wallet provider or bridge from another network before connecting to Shareland.
+    You need USDC on the Base network to trade. Send USDC from a crypto exchange (like Coinbase) to your wallet address on Base. If you signed up with email or Google, your wallet address is shown in the app. See [Fund Your Account](/how-to/fund-your-account) for step-by-step instructions.
   </Accordion>
   <Accordion title="Is Shareland regulated?">
     SQFT tokens are structured as synthetic derivative instruments, not securities. Shareland is pursuing regulatory clarity under the **CFTC** framework. See our [Terms of Service](https://share.land/terms) for the full legal picture.


### PR DESCRIPTION
## Summary

- Updates funding docs to remove ETH as a hard requirement — most wallets handle gas with USDC natively
- Updates create-account docs to reflect current sign-in options (email, Google, external wallets via Privy)
- Adds sign-up FAQ and updates funding FAQ with current information

## Changes

- **`fund-your-account.mdx`**: Removed ETH as a requirement, simplified to USDC-only flow, updated FAQ to explain gas is handled automatically
- **`create-account.mdx`**: Replaced "connect your wallet" with email/Google/wallet sign-in options, added embedded wallet tip
- **`faq.mdx`**: Added "How do I sign up?" FAQ, updated "How do I add funds?" with current USDC-only info

## Testing
- [ ] All pages render correctly on docs.share.land preview
- [ ] No broken links or references
- [ ] FAQ answers are accurate and consistent with fund-your-account page

## Related Issues
Closes #7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code, auth, or payment logic modified.
> 
> **Overview**
> Updates onboarding and funding docs to match the current **Privy** sign-in flow and a **USDC-only** funding story on Base.
> 
> **Create account** now describes signing in with email, Google, or an external wallet (instead of wallet-only), removes the “future login methods” note, and adds a tip that email/Google users get an embedded wallet automatically.
> 
> **Fund your account** drops ETH as a prerequisite throughout (description, steps, verification, mistakes) and reframes the gas FAQ: most wallets pay gas from USDC; ETH is only a possible fallback.
> 
> **FAQ** adds a sign-up answer and replaces the vague funding blurb with USDC-on-Base steps and a link to the funding guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80188446479c8fe238a689e7cdf63093d7f9fc07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->