### PR TITLE
docs: evergreen restricted jurisdictions → ToS v1.2

### DIFF
--- a/reference/faq.mdx
+++ b/reference/faq.mdx
@@ -7,7 +7,7 @@ description: Answers to the most common questions about Shareland.
 
 <AccordionGroup>
   <Accordion title="Is Shareland available in my country?">
-    Shareland is not available to citizens or residents of the United States, Canada, UK, Mainland China, Cuba, Iran, North Korea, Syria, Myanmar, Afghanistan, Belarus, Central African Republic, DR Congo, Libya, Mali, Nicaragua, Somalia, Sudan, Venezuela, Yemen, Zimbabwe, or the Crimea/Donetsk/Luhansk regions.
+    Shareland is not available if you are located in, incorporated in, or a resident or citizen of a **Restricted Jurisdiction** as defined in our [Terms of Service](https://share.land/terms) (v1.2, effective June 30, 2026). That page lists all blocked countries and regions.
 
     During sign-up, you'll be asked to confirm your jurisdiction. Users in restricted countries will not be able to access the exchange. Using a VPN to bypass geofencing is a violation of our Terms of Service.
   </Accordion>

--- a/reference/regulatory.mdx
+++ b/reference/regulatory.mdx
@@ -13,9 +13,7 @@ SQFT tokens are synthetic derivative instruments designed to track the price per
 
 ## Restricted Jurisdictions
 
-Shareland is **strictly prohibited** for citizens, residents, and persons physically located in the following jurisdictions:
-
-**United States** (including all states and territories), **Canada**, **United Kingdom**, **Mainland China**, **Cuba**, **Iran**, **North Korea**, **Syria**, **Myanmar**, **Afghanistan**, **Belarus**, **Central African Republic**, **DR Congo**, **Libya**, **Mali**, **Nicaragua**, **Somalia**, **Sudan**, **Venezuela**, **Yemen**, **Zimbabwe**, and the **Crimea, Donetsk, and Luhansk regions**.
+Shareland is **strictly prohibited** for citizens, residents, and persons physically located in any **Restricted Jurisdiction** as defined in our [Terms of Service](https://share.land/terms) (v1.2, effective June 30, 2026). That page is the authoritative list of blocked countries and regions.
 
 Use of a VPN or other circumvention tool to bypass geofencing is a violation of our Terms of Service and subjects you to full indemnification liability.
 
@@ -29,6 +27,4 @@ Shareland operates as a non-custodial software interface. SQFT tokens are synthe
 
 ## Terms of Service
 
-Full legal terms effective January 31, 2026. Shareland, Inc. is incorporated in Delaware.
-
-[Read the full Terms of Service](https://share.land/terms)
+Full legal terms: [Terms of Service on share.land](https://share.land/terms) (v1.2, effective June 30, 2026). Shareland, Inc. is incorporated in Delaware.


### PR DESCRIPTION
## Summary
- Point restricted-jurisdiction copy to the authoritative Terms page (v1.2, effective June 30, 2026)
- Remove inline country lists from FAQ and regulatory pages — less to maintain when the list changes

## Changes
- `reference/faq.mdx` — evergreen availability answer links to share.land/terms
- `reference/regulatory.mdx` — Restricted Jurisdictions section references ToS; updated effective date

## Related Issues
Relates to Shareland/shareland-react#484

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and link updates; no product or enforcement logic changes.
> 
> **Overview**
> **FAQ** and **regulatory** copy no longer embed a long inline list of blocked countries. Availability and restricted-jurisdiction language now points readers to the authoritative **Restricted Jurisdiction** definition on [share.land/terms](https://share.land/terms) (**v1.2**, effective **June 30, 2026**).
> 
> The regulatory page’s **Terms of Service** blurb is updated to the same version and effective date (replacing January 31, 2026). VPN/geofencing warnings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f738a66f84aefd0db19845801f23de375a099b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->